### PR TITLE
escape some text may contain xml special char `<&>`

### DIFF
--- a/src/gamer/GamerHomeCreation.php
+++ b/src/gamer/GamerHomeCreation.php
@@ -182,14 +182,14 @@ class GamerHomeCreation {
 
         foreach ($this->entries as $id => $entry) {
             $item = $channel->addChild('item');
-                $item->addChild('title', $entry['title']);
+                $item->addChild('title', htmlspecialchars($entry['title']));
                 $item->addChild('link', $entry['link']);
-                $item->addChild('author', $entry['author']);
+                $item->addChild('author', htmlspecialchars($entry['author']));
                 $description = $entry['description'];
                 if (!empty($entry['image'])) {
                     $description = '<img src="' . $entry['image'] . '"><br>' . $description;
                 }
-                $item->addChild('description', $description);
+                $item->addChild('description', htmlspecialchars($description));
                 $item->addChild('pubDate', date("D, j M Y H:i:s +0800", strtotime($entry['pubDate'])));
         }
 


### PR DESCRIPTION
your code may encounter this warning:
https://stackoverflow.com/questions/17027043/unterminated-entity-reference-in-php
so I escape title, author and description in entry.

for example in this gamer home:
https://home.gamer.com.tw/creation.php?owner=mitsueyn ,
it contain `&` in article title, and your code would produce incorrect rss.

you can test with following command:

```sh
php -r '
include("vendor/autoload.php");
function userRss($owner, $maxPage) {
    $GamerHomeCreation = new wsmwason\gamer\GamerHomeCreation($owner);
    $GamerHomeCreation->setOwner($owner);
    $GamerHomeCreation->setMaxCrawlPage($maxPage);
    return $GamerHomeCreation->asXml();
}

$owner = $argv[1];
userRss($owner, 1);
' mitsueyn
```